### PR TITLE
Fix blank wallpaper thumbnails rendering in Plasma 6

### DIFF
--- a/package/contents/ui/WallpaperDelegate.qml
+++ b/package/contents/ui/WallpaperDelegate.qml
@@ -57,24 +57,23 @@ KCM.GridDelegate {
     thumbnail: Rectangle {
         id: backgroundRect
         anchors.fill: parent
+        color: Kirigami.Theme.backgroundColor
 
         Kirigami.Icon {
             anchors.centerIn: parent
             width: Kirigami.Units.iconSizes.large
             height: width
             source: "view-preview"
-            visible: !walliePreview.visible
+            visible: walliePreview.status !== Image.Ready
         }
 
-        QPixmapItem {
+        Image {
             id: walliePreview
             anchors.fill: parent
-            visible: model.screenshot !== null
-            smooth: true
-            pixmap: model.screenshot
-            fillMode: {
-                return QPixmapItem.PreserveAspectCrop;
-            }
+            asynchronous: true
+            sourceSize: Qt.size(parent.width, parent.height)
+            source: model.path 
+            fillMode: Image.PreserveAspectCrop
         }
     }
 


### PR DESCRIPTION
Hi! I've been using this plugin on Plasma 6 and noticed that the wallpaper previews in the settings dialog were rendering as blank white rectangles.
<img width="1863" height="898" alt="Screenshot_20251211_095905" src="https://github.com/user-attachments/assets/b7d73af0-d9f1-4366-a9b5-cd8d3e87c222" />


It appears that `QPixmapItem` combined with `model.screenshot` isn't behaving correctly in the new Plasma version, failing to render the thumbnail data.

**Changes:**
1. **Replaced `QPixmapItem` with `Image`:** I switched the delegate to use the standard QML `Image` component. This fixes the blank rendering issue.
2. Added `sourceSize: Qt.size(parent.width, parent.height)` since now it is loading the full image files, to allow faster rendering.
3. Added a `Kirigami.Icon` placeholder that is visible while the image loads asynchronously, like the standard behaviour of the KDE wallpaper plugin.

Hope this is helpful :)