### PR TITLE
replaced model.path and model.packageName with model.preview and model.source

### DIFF
--- a/package/contents/ui/WallpaperDelegate.qml
+++ b/package/contents/ui/WallpaperDelegate.qml
@@ -72,7 +72,7 @@ KCM.GridDelegate {
             anchors.fill: parent
             asynchronous: true
             sourceSize: Qt.size(parent.width, parent.height)
-            source: model.path 
+            source: model.preview 
             fillMode: Image.PreserveAspectCrop
         }
     }
@@ -85,7 +85,7 @@ KCM.GridDelegate {
     }
 
     onClicked: {
-        cfg_Image = model.packageName || model.path;
+        cfg_Image = model.source;
         if (typeof wallpaper !== "undefined") {
             wallpaper.configuration.PreviewImage = cfg_Image;
         }

--- a/plasma-parallax.patch
+++ b/plasma-parallax.patch
@@ -1,0 +1,191 @@
+--- /tmp/plasma-parallax-wallpaper/package/contents/ui/WallpaperDelegate.qml	2026-02-28 20:53:07.093417440 +0100
++++ /home/florian/.local/share/plasma/wallpapers/com.github.bojidar-bg.parallax/contents/ui/WallpaperDelegate.qml	2026-02-28 21:50:43.864145267 +0100
+@@ -1,94 +1,94 @@
+-/*
+-    SPDX-FileCopyrightText: 2013 Marco Martin <mart@kde.org>
+-    SPDX-FileCopyrightText: 2014 Sebastian Kügler <sebas@kde.org>
+-
+-    SPDX-License-Identifier: GPL-2.0-or-later
+-
+-    (based on https://invent.kde.org/plasma/plasma-workspace/-/blob/master/wallpapers/image/imagepackage/contents/ui/WallpaperDelegate.qml, 2024-03-09)
+-*/
+-
+-import QtQuick
+-import QtQuick.Controls as QtControls2
+-import Qt5Compat.GraphicalEffects
+-
+-import org.kde.kirigami as Kirigami
+-import org.kde.kquickcontrolsaddons
+-import org.kde.kcmutils as KCM
+-
+-KCM.GridDelegate {
+-    id: wallpaperDelegate
+-
+-    opacity: model.pendingDeletion ? 0.5 : 1
+-    scale: index, 1 // Workaround for https://bugreports.qt.io/browse/QTBUG-107458
+-
+-    text: model.display
+-    subtitle: model.author
+-
+-    hoverEnabled: true
+-
+-    actions: [
+-        Kirigami.Action {
+-            icon.name: "document-open-folder"
+-            tooltip: i18nd("plasma_wallpaper_org.kde.image", "Open Containing Folder")
+-            onTriggered: imageModel.openContainingFolder(index)
+-        },
+-        Kirigami.Action {
+-            icon.name: "edit-undo"
+-            visible: model.pendingDeletion
+-            tooltip: i18nd("plasma_wallpaper_org.kde.image", "Restore wallpaper")
+-            onTriggered: model.pendingDeletion = false
+-        },
+-        Kirigami.Action {
+-            icon.name: "edit-delete"
+-            tooltip: i18nd("plasma_wallpaper_org.kde.image", "Remove Wallpaper")
+-            visible: model.removable && !model.pendingDeletion
+-            onTriggered: {
+-                model.pendingDeletion = true;
+-
+-                if (wallpapersGrid.view.currentIndex === index) {
+-                    const newIndex = (index + 1) % (imageModel.count - 1);
+-                    wallpapersGrid.view.itemAtIndex(newIndex).clicked();
+-                }
+-                root.configurationChanged(); // BUG 438585
+-            }
+-        }
+-    ]
+-
+-    thumbnail: Rectangle {
+-        id: backgroundRect
+-        anchors.fill: parent
+-        color: Kirigami.Theme.backgroundColor
+-
+-        Kirigami.Icon {
+-            anchors.centerIn: parent
+-            width: Kirigami.Units.iconSizes.large
+-            height: width
+-            source: "view-preview"
+-            visible: walliePreview.status !== Image.Ready
+-        }
+-
+-        Image {
+-            id: walliePreview
+-            anchors.fill: parent
+-            asynchronous: true
+-            sourceSize: Qt.size(parent.width, parent.height)
+-            source: model.path 
+-            fillMode: Image.PreserveAspectCrop
+-        }
+-    }
+-
+-    Behavior on opacity {
+-        OpacityAnimator {
+-            duration: Kirigami.Units.longDuration
+-            easing.type: Easing.InOutQuad
+-        }
+-    }
+-
+-    onClicked: {
+-        cfg_Image = model.packageName || model.path;
+-        if (typeof wallpaper !== "undefined") {
+-            wallpaper.configuration.PreviewImage = cfg_Image;
+-        }
+-        GridView.currentIndex = index;
+-    }
+-}
++/*
++    SPDX-FileCopyrightText: 2013 Marco Martin <mart@kde.org>
++    SPDX-FileCopyrightText: 2014 Sebastian Kügler <sebas@kde.org>
++
++    SPDX-License-Identifier: GPL-2.0-or-later
++
++    (based on https://invent.kde.org/plasma/plasma-workspace/-/blob/master/wallpapers/image/imagepackage/contents/ui/WallpaperDelegate.qml, 2024-03-09)
++*/
++
++import QtQuick
++import QtQuick.Controls as QtControls2
++import Qt5Compat.GraphicalEffects
++
++import org.kde.kirigami as Kirigami
++import org.kde.kquickcontrolsaddons
++import org.kde.kcmutils as KCM
++
++KCM.GridDelegate {
++    id: wallpaperDelegate
++
++    opacity: model.pendingDeletion ? 0.5 : 1
++    scale: index, 1 // Workaround for https://bugreports.qt.io/browse/QTBUG-107458
++
++    text: model.display
++    subtitle: model.author
++
++    hoverEnabled: true
++
++    actions: [
++        Kirigami.Action {
++            icon.name: "document-open-folder"
++            tooltip: i18nd("plasma_wallpaper_org.kde.image", "Open Containing Folder")
++            onTriggered: imageModel.openContainingFolder(index)
++        },
++        Kirigami.Action {
++            icon.name: "edit-undo"
++            visible: model.pendingDeletion
++            tooltip: i18nd("plasma_wallpaper_org.kde.image", "Restore wallpaper")
++            onTriggered: model.pendingDeletion = false
++        },
++        Kirigami.Action {
++            icon.name: "edit-delete"
++            tooltip: i18nd("plasma_wallpaper_org.kde.image", "Remove Wallpaper")
++            visible: model.removable && !model.pendingDeletion
++            onTriggered: {
++                model.pendingDeletion = true;
++
++                if (wallpapersGrid.view.currentIndex === index) {
++                    const newIndex = (index + 1) % (imageModel.count - 1);
++                    wallpapersGrid.view.itemAtIndex(newIndex).clicked();
++                }
++                root.configurationChanged(); // BUG 438585
++            }
++        }
++    ]
++
++    thumbnail: Rectangle {
++        id: backgroundRect
++        anchors.fill: parent
++        color: Kirigami.Theme.backgroundColor
++
++        Kirigami.Icon {
++            anchors.centerIn: parent
++            width: Kirigami.Units.iconSizes.large
++            height: width
++            source: "view-preview"
++            visible: walliePreview.status !== Image.Ready
++        }
++
++        Image {
++            id: walliePreview
++            anchors.fill: parent
++            asynchronous: true
++            sourceSize: Qt.size(parent.width, parent.height)
++            source: model.preview 
++            fillMode: Image.PreserveAspectCrop
++        }
++    }
++
++    Behavior on opacity {
++        OpacityAnimator {
++            duration: Kirigami.Units.longDuration
++            easing.type: Easing.InOutQuad
++        }
++    }
++
++    onClicked: {
++        cfg_Image = model.packageName || model.source;
++        if (typeof wallpaper !== "undefined") {
++            wallpaper.configuration.PreviewImage = cfg_Image;
++        }
++        GridView.currentIndex = index;
++    }
++}


### PR DESCRIPTION
because they were changed in plasma (see PR https://invent.kde.org/plasma/plasma-workspace/-/merge_requests/5983)